### PR TITLE
Update sdfz-demo-parser and spring-map-parser dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
         "got": "^11.8.3",
         "node-7z": "^2.1.2",
         "octonode": "^0.10.2",
-        "sdfz-demo-parser": "^4.7.0",
-        "spring-map-parser": "^2.1.0",
+        "sdfz-demo-parser": "^4.8.0",
+        "spring-map-parser": "^4.4.0",
         "spring-nextgen-dl": "^0.2.3",
         "yargs": "^15.4.1"
       },
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -1846,15 +1846,6 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/jimp": {
-      "version": "0.2.28",
-      "resolved": "https://registry.npmjs.org/@types/jimp/-/jimp-0.2.28.tgz",
-      "integrity": "sha512-nLIVbImtcaEf90y2XQsMzfgWK5EZxfDg6EVWobrkFTFJiLqmx/yU5Jh+LYUN94ztzXX1GwQLFYHaEi8tfMeZzw==",
-      "deprecated": "This is a stub types definition for jimp (https://github.com/oliver-moran/jimp#readme). jimp provides its own type definitions, so you don't need @types/jimp installed!",
-      "dependencies": {
-        "jimp": "*"
       }
     },
     "node_modules/@types/keyv": {
@@ -3740,14 +3731,6 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
-    "node_modules/dxt-js": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/dxt-js/-/dxt-js-0.0.3.tgz",
-      "integrity": "sha512-qNBx0i5/ICyNFO7rs5ZothChgfFD408dg/ZBBfWFXDy0xeDQ86t91QUZxj5WqeUzZQ/+PPtjTUC0w3mS+198jg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -5147,11 +5130,11 @@
       }
     },
     "node_modules/gifwrap": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.2.tgz",
-      "integrity": "sha512-fcIswrPaiCDAyO8xnWvHSZdWChjKXUanKKpAiWWJ/UTkEi/aYKn5+90e7DE820zbEaVR9CE2y4z9bzhQijZ0BA==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.4.tgz",
+      "integrity": "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ==",
       "dependencies": {
-        "image-q": "^1.1.1",
+        "image-q": "^4.0.0",
         "omggif": "^1.0.10"
       }
     },
@@ -5606,12 +5589,17 @@
       }
     },
     "node_modules/image-q": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/image-q/-/image-q-1.1.1.tgz",
-      "integrity": "sha1-/IQJlmRGC5DKhi2TALa/u7+/gFY=",
-      "engines": {
-        "node": ">=0.9.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
+      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
+      "dependencies": {
+        "@types/node": "16.9.1"
       }
+    },
+    "node_modules/image-q/node_modules/@types/node": {
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -6171,18 +6159,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/jaz-signals": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/jaz-signals/-/jaz-signals-0.3.0.tgz",
-      "integrity": "sha512-HAoakA6aA6Lg2ZYmwsP5LCL02JSLPIY/6mtBJz3Mh0B0MvlenlvxA2ieAo5kuhDwUWcjzB78+LWtZhBtVzNs+A=="
-    },
     "node_modules/jaz-ts-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/jaz-ts-utils/-/jaz-ts-utils-0.3.1.tgz",
-      "integrity": "sha512-4n7lo+9BkuJSCIWeQqvX+HCC39eLxWCfm798yWqAnvs/uLofAuaTqB+6bQErwRTBjOR2HVGcWSRRW5m+ay26hA==",
-      "dependencies": {
-        "typescript": "^4.1.3"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jaz-ts-utils/-/jaz-ts-utils-3.0.0.tgz",
+      "integrity": "sha512-PUfXwGhVX7+8Kh7fv93xwaNBxG8LLWpYBnIDR/gG3veKSKLmVx1Po/uOINKVO7YJRBHFHq695vtaoIWz0Gb9sQ=="
     },
     "node_modules/jest": {
       "version": "26.6.3",
@@ -7173,6 +7153,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/luaparse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/luaparse/-/luaparse-0.3.1.tgz",
+      "integrity": "sha512-b21h2bFEbtGXmVqguHogbyrMAA0wOHyp9u/rx+w6Yc9pW1t9YjhGUsp87lYcp7pFRqSWN/PhFkrdIqKEUzRjjQ==",
+      "bin": {
+        "luaparse": "bin/luaparse"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -8023,9 +8011,9 @@
       }
     },
     "node_modules/parse-headers": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
-      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
+      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -9100,13 +9088,12 @@
       }
     },
     "node_modules/sdfz-demo-parser": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/sdfz-demo-parser/-/sdfz-demo-parser-4.7.0.tgz",
-      "integrity": "sha512-nwQbNCWLqifNMOFdiR36FjhiqwWXjkSdvMMh7zI2v4trU+nC53QK/w0BdMZn76irUnuLsEReww6scazTGd5j4w==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/sdfz-demo-parser/-/sdfz-demo-parser-4.8.0.tgz",
+      "integrity": "sha512-pdAPaWJtYIRhOY4VNafITi69bPFys3SIE/E4BPvuySGhHTfVkbqLBVy/uMjm/YcF+mwJhOCL5FPtT20ReAdlHg==",
       "dependencies": {
-        "jaz-ts-utils": "^0.3.1",
-        "node-gzip": "^1.1.2",
-        "typescript": "^4.1.3"
+        "jaz-ts-utils": "^3.0.0",
+        "node-gzip": "^1.1.2"
       }
     },
     "node_modules/semver": {
@@ -9556,28 +9543,17 @@
       }
     },
     "node_modules/spring-map-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spring-map-parser/-/spring-map-parser-2.1.0.tgz",
-      "integrity": "sha512-8y/sXWaX/6OH4izHy+B6aQuddVocj4Y9yjOBYVXuYCJ3VvyAzn44/kZcau1Olj6htL25nX20bfYmb3eoUuXOuw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/spring-map-parser/-/spring-map-parser-4.4.0.tgz",
+      "integrity": "sha512-9XT2l+i1uQ40d985mSmwMm1zAVbQJUWlkoIrYogX2NUGM8YULoCsV1p68IPubv2n8LpRj1YPCosyF1Nzeg39lQ==",
       "dependencies": {
-        "@types/jimp": "^0.2.28",
         "7zip-bin": "^5.0.3",
-        "dxt-js": "0.0.3",
         "glob": "^7.1.6",
-        "jaz-signals": "^0.3.0",
-        "jaz-ts-utils": "^0.1.0",
+        "jaz-ts-utils": "^3.0.0",
         "jimp": "^0.16.1",
+        "luaparse": "^0.3.1",
         "node-7z": "^2.1.2",
-        "node-stream-zip": "^1.13.0",
-        "typescript": "^4.1.3"
-      }
-    },
-    "node_modules/spring-map-parser/node_modules/jaz-ts-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/jaz-ts-utils/-/jaz-ts-utils-0.1.0.tgz",
-      "integrity": "sha512-O9MyTwxyBpcOCzXmub6MKCfW/1EgEKF5j2gNDHe0kOc/jDgohcrJnBWuiNR+PGpxdWHPLfAhYgw00babgZO1nA==",
-      "dependencies": {
-        "typescript": "^4.1.3"
+        "node-stream-zip": "^1.13.0"
       }
     },
     "node_modules/spring-nextgen-dl": {
@@ -10345,18 +10321,6 @@
       "dev": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/union-value": {
@@ -11323,9 +11287,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -12404,14 +12368,6 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "@types/jimp": {
-      "version": "0.2.28",
-      "resolved": "https://registry.npmjs.org/@types/jimp/-/jimp-0.2.28.tgz",
-      "integrity": "sha512-nLIVbImtcaEf90y2XQsMzfgWK5EZxfDg6EVWobrkFTFJiLqmx/yU5Jh+LYUN94ztzXX1GwQLFYHaEi8tfMeZzw==",
-      "requires": {
-        "jimp": "*"
       }
     },
     "@types/keyv": {
@@ -13887,11 +13843,6 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
-    "dxt-js": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/dxt-js/-/dxt-js-0.0.3.tgz",
-      "integrity": "sha512-qNBx0i5/ICyNFO7rs5ZothChgfFD408dg/ZBBfWFXDy0xeDQ86t91QUZxj5WqeUzZQ/+PPtjTUC0w3mS+198jg=="
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -14999,11 +14950,11 @@
       }
     },
     "gifwrap": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.2.tgz",
-      "integrity": "sha512-fcIswrPaiCDAyO8xnWvHSZdWChjKXUanKKpAiWWJ/UTkEi/aYKn5+90e7DE820zbEaVR9CE2y4z9bzhQijZ0BA==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.4.tgz",
+      "integrity": "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ==",
       "requires": {
-        "image-q": "^1.1.1",
+        "image-q": "^4.0.0",
         "omggif": "^1.0.10"
       }
     },
@@ -15339,9 +15290,19 @@
       "dev": true
     },
     "image-q": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/image-q/-/image-q-1.1.1.tgz",
-      "integrity": "sha1-/IQJlmRGC5DKhi2TALa/u7+/gFY="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
+      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
+      "requires": {
+        "@types/node": "16.9.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.9.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+          "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
+        }
+      }
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -15761,18 +15722,10 @@
         }
       }
     },
-    "jaz-signals": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/jaz-signals/-/jaz-signals-0.3.0.tgz",
-      "integrity": "sha512-HAoakA6aA6Lg2ZYmwsP5LCL02JSLPIY/6mtBJz3Mh0B0MvlenlvxA2ieAo5kuhDwUWcjzB78+LWtZhBtVzNs+A=="
-    },
     "jaz-ts-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/jaz-ts-utils/-/jaz-ts-utils-0.3.1.tgz",
-      "integrity": "sha512-4n7lo+9BkuJSCIWeQqvX+HCC39eLxWCfm798yWqAnvs/uLofAuaTqB+6bQErwRTBjOR2HVGcWSRRW5m+ay26hA==",
-      "requires": {
-        "typescript": "^4.1.3"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jaz-ts-utils/-/jaz-ts-utils-3.0.0.tgz",
+      "integrity": "sha512-PUfXwGhVX7+8Kh7fv93xwaNBxG8LLWpYBnIDR/gG3veKSKLmVx1Po/uOINKVO7YJRBHFHq695vtaoIWz0Gb9sQ=="
     },
     "jest": {
       "version": "26.6.3",
@@ -16577,6 +16530,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "luaparse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/luaparse/-/luaparse-0.3.1.tgz",
+      "integrity": "sha512-b21h2bFEbtGXmVqguHogbyrMAA0wOHyp9u/rx+w6Yc9pW1t9YjhGUsp87lYcp7pFRqSWN/PhFkrdIqKEUzRjjQ=="
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -17247,9 +17205,9 @@
       }
     },
     "parse-headers": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
-      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
+      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "parse-json": {
       "version": "5.2.0",
@@ -18089,13 +18047,12 @@
       }
     },
     "sdfz-demo-parser": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/sdfz-demo-parser/-/sdfz-demo-parser-4.7.0.tgz",
-      "integrity": "sha512-nwQbNCWLqifNMOFdiR36FjhiqwWXjkSdvMMh7zI2v4trU+nC53QK/w0BdMZn76irUnuLsEReww6scazTGd5j4w==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/sdfz-demo-parser/-/sdfz-demo-parser-4.8.0.tgz",
+      "integrity": "sha512-pdAPaWJtYIRhOY4VNafITi69bPFys3SIE/E4BPvuySGhHTfVkbqLBVy/uMjm/YcF+mwJhOCL5FPtT20ReAdlHg==",
       "requires": {
-        "jaz-ts-utils": "^0.3.1",
-        "node-gzip": "^1.1.2",
-        "typescript": "^4.1.3"
+        "jaz-ts-utils": "^3.0.0",
+        "node-gzip": "^1.1.2"
       }
     },
     "semver": {
@@ -18465,30 +18422,17 @@
       }
     },
     "spring-map-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spring-map-parser/-/spring-map-parser-2.1.0.tgz",
-      "integrity": "sha512-8y/sXWaX/6OH4izHy+B6aQuddVocj4Y9yjOBYVXuYCJ3VvyAzn44/kZcau1Olj6htL25nX20bfYmb3eoUuXOuw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/spring-map-parser/-/spring-map-parser-4.4.0.tgz",
+      "integrity": "sha512-9XT2l+i1uQ40d985mSmwMm1zAVbQJUWlkoIrYogX2NUGM8YULoCsV1p68IPubv2n8LpRj1YPCosyF1Nzeg39lQ==",
       "requires": {
-        "@types/jimp": "^0.2.28",
         "7zip-bin": "^5.0.3",
-        "dxt-js": "0.0.3",
         "glob": "^7.1.6",
-        "jaz-signals": "^0.3.0",
-        "jaz-ts-utils": "^0.1.0",
+        "jaz-ts-utils": "^3.0.0",
         "jimp": "^0.16.1",
+        "luaparse": "^0.3.1",
         "node-7z": "^2.1.2",
-        "node-stream-zip": "^1.13.0",
-        "typescript": "^4.1.3"
-      },
-      "dependencies": {
-        "jaz-ts-utils": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/jaz-ts-utils/-/jaz-ts-utils-0.1.0.tgz",
-          "integrity": "sha512-O9MyTwxyBpcOCzXmub6MKCfW/1EgEKF5j2gNDHe0kOc/jDgohcrJnBWuiNR+PGpxdWHPLfAhYgw00babgZO1nA==",
-          "requires": {
-            "typescript": "^4.1.3"
-          }
-        }
+        "node-stream-zip": "^1.13.0"
       }
     },
     "spring-nextgen-dl": {
@@ -19101,11 +19045,6 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "got": "^11.8.3",
     "node-7z": "^2.1.2",
     "octonode": "^0.10.2",
-    "sdfz-demo-parser": "^4.7.0",
-    "spring-map-parser": "^2.1.0",
+    "sdfz-demo-parser": "^4.8.0",
+    "spring-map-parser": "^4.4.0",
     "spring-nextgen-dl": "^0.2.3",
     "yargs": "^15.4.1"
   },


### PR DESCRIPTION
Based on #101

This updates sdfz-demo-parser and spring-map-parser, but also indirectly gifwrap, which makes it include following 3 PRs:
- https://github.com/Jazcash/sdfz-demo-parser/pull/9
- https://github.com/Jazcash/spring-map-parser/pull/13
- https://github.com/jtlapp/gifwrap/pull/37

that brings the size of launched down by another 20MiB, and we are now at 108MiB.